### PR TITLE
Changing regexMatch to block form

### DIFF
--- a/yomichan_templates/bottom.txt
+++ b/yomichan_templates/bottom.txt
@@ -792,7 +792,7 @@
 
 
 {{#*inline "jpmn-frequency-sort"}}
-    {{~! Frequency sort handlebars: v23.03.13.1 ~}}
+    {{~! Frequency sort handlebars: v24.01.06.1 ~}}
     {{~! The latest version can be found at https://github.com/MarvNC/JP-Resources#freq-handlebar ~}}
     {{~#scope~}}
 

--- a/yomichan_templates/bottom.txt
+++ b/yomichan_templates/bottom.txt
@@ -107,7 +107,9 @@
         {{~#each definition.definitions~}}
             {{~#set "search-def"}}{{~> _jpmn-glossary-single-search . brief=../brief noDictionaryTag=../noDictionaryTag ~}}{{/set~}}
 
-            {{~set "search-regex-match" (regexMatch (get "search-selection") "gu" (get "search-def"))}}
+            {{~#set "search-regex-match"}}
+                {{~#regexMatch (get "search-selection") "gu"}}{{~get "search-def"~}}{{/regexMatch~}}
+            {{/set~}}
             {{~#if (op "&&"
                 (op "===" (get "result-dictionary") null)
                 (op "!==" (get "search-regex-match") "")
@@ -854,7 +856,8 @@
                 {{/if~}}
 
                 {{~#if (get "read-freq") ~}}
-                    {{~set "f" (op "+" (regexMatch "\d+" "" this.frequency)) ~}}
+                    {{~#set "numericFrequencyMatch"}}{{~#regexMatch "\d+" ""}}{{~this.frequency~}}{{/regexMatch~}}{{/set~}}
+                    {{~set "f" (op "+" (get "numericFrequencyMatch")) ~}}
 
                     {{~#if (op "===" (get "opt-freq-sorting-method") "min") ~}}
                         {{~#if

--- a/yomichan_templates/top.txt
+++ b/yomichan_templates/top.txt
@@ -34,7 +34,7 @@
 {{~! See here for the official documentation on how these options work:
     https://github.com/MarvNC/JP-Resources#freq-settings ~}}
 
-{{~#set "opt-ignored-freq-dict-regex"~}} ^(JLPT_Level)$ {{~/set~}}
+{{~#set "opt-ignored-freq-dict-regex"~}} ^(JLPT.*)|(HSK.*)$ {{~/set~}}
 {{~#set "opt-ignored-freq-value-regex"~}} ❌ {{~/set~}}
 {{~#set "opt-keep-freqs-past-first-regex"~}} ^()$ {{~/set~}}
 {{~set "opt-no-freq-default-value" 9999999 ~}}


### PR DESCRIPTION
Fixes #3, also fixes manual selection of the primary definition. But, I did not fix the `jpmn-min-freq` handlebar because it's supposedly deprecated.

The problem is that `regexMatch` no longer works in the form `{{regexMatch regex [flags] [text-to-modify]...}}`. Instead, it only works in the form `{{#regexMatch regex [flags]}}text-to-modify{{/regexMatch}}`. Maybe an issue should be raised in Yomitan?